### PR TITLE
Feature/LIBWHCA-140

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tests/scutes/test_data/*
 
 data/db/*
 src/media/*
+src/scutes.egg-info/*

--- a/src/processing/common/export.py
+++ b/src/processing/common/export.py
@@ -1,0 +1,115 @@
+import logging
+import sys
+import zipfile
+
+from bs4 import BeautifulSoup
+from csv import DictWriter
+from pathlib import Path
+
+from django.core.management import BaseCommand
+
+from processing.models import Batch, File, Item
+
+
+logger = logging.getLogger(__name__)
+
+HEADER = ['Identifier', 'Title', 'Date', 'Creator', 'Format', 'Rights Statement', 'FILES', 'Object Type']
+
+
+def export(batch_selected, export_path):
+    batch = Batch.objects.get(id=batch_selected)
+    batch_selected_name = batch.name
+    # Check if all items are reviewed
+    total_items_count = Item.objects.filter(batch=batch_selected).count()
+    not_reviewed = Item.objects.filter(batch=batch_selected, review_status=False)
+    not_reviewed_count = not_reviewed.count()
+    if not_reviewed_count != 0:
+        logger.info('Not all items in this batch have been reviewed.')
+        logger.info(f'Number of items not reviewed: {not_reviewed_count} out of {total_items_count}')
+        result = input('Continue export? Please answer yes or no: ')
+        if result == 'yes':
+            pass
+        else:
+            logger.info('Exiting Script')
+            sys.exit()
+    else:
+        pass
+    # Select items only in selected batch and marked publish
+    items = Item.objects.filter(batch=batch_selected, publish=True)
+    # Create output path if not exists
+    path = Path(export_path, batch_selected_name)
+    path.mkdir(parents=True, exist_ok=True)
+    output_path = path
+    # Open the output CSV for writing
+    with open(output_path / 'whpool.csv', 'w') as csv_file:
+        csv_writer = DictWriter(csv_file, fieldnames=HEADER, extrasaction='ignore', escapechar='\\')
+        # Add the headers
+        csv_writer.writeheader()
+        # Iterate over items in database
+        for item in items:
+            logger.info(f'Exporting: {item.id}, {item.title}')
+            files_path = []
+            # Create HTML file
+            id = str(item.id)
+            body_name = 'body-' + id + '.html'
+            body = Path(output_path / id / body_name)
+            body.parent.mkdir(parents=True, exist_ok=True)
+            with open(body, 'w') as body:
+                body.write(item.body_final)
+            file_path = id + '/' + body_name
+            files_path.append(file_path)
+            # Create attachment file
+            files = File.objects.filter(item=item)
+            for file in files:
+                if file.disposition == 'attachment':
+                    file_name = file.name
+                    file_path = Path(output_path / id / 'attachments' / file_name)
+                    file_path.parent.mkdir(parents=True, exist_ok=True)
+                    file_to_download = file.file.read()
+                    with open(file_path, 'wb') as f:
+                        f.write(file_to_download)
+                    file_path = id + '/' + 'media' + '/' + file_name
+                    files_path.append(file_path)
+                elif file.disposition == 'inline':
+                    file_name = file.file.name
+                    file_path = Path(output_path / id / 'media' / file_name)
+                    file_path.parent.mkdir(parents=True, exist_ok=True)
+                    file_to_download = file.file.read()
+                    with open(file_path, 'wb') as f:
+                        f.write(file_to_download)
+                    file_path = id + '/' + 'media' + '/' + file_name
+                    files_path.append(file_path)
+                elif file.disposition == 'external':
+                    file_name = file.file.name
+                    file_path = Path(output_path / id / 'media' / file_name)
+                    file_path.parent.mkdir(parents=True, exist_ok=True)
+                    file_to_download = file.file.read()
+                    with open(file_path, 'wb') as f:
+                        f.write(file_to_download)
+                    file_path = id + '/' + 'media' + '/' + file_name
+                    files_path.append(file_path)
+                else:
+                    pass
+            # Write CSV row
+            csv_writer.writerow(
+                {
+                    'Identifier': item.id,
+                    'Title': item.title,
+                    'Date': item.date,
+                    'Creator': item.reporter,
+                    'Format': 'http://vocab.lib.umd.edu/form#pool_reports',
+                    'Rights Statement': 'http://vocab.lib.umd.edu/rightsStatement#InC-NC',
+                    'FILES': ';'.join(files_path),
+                    'Object Type': 'http://purl.org/dc/dcmitype/Text',
+                }
+            )
+    # Zip directory
+    directory = Path(output_path)
+    logger.info(f'Creating zip file for {directory}')
+    zip_file_name = batch_selected_name + '.zip'
+    zip_file = Path(directory.parent / zip_file_name)
+    with zipfile.ZipFile(zip_file, mode='w') as archive:
+        for file_path in directory.rglob('*'):
+            archive.write(file_path, arcname=file_path.relative_to(directory))
+    with zipfile.ZipFile(zip_file, mode='r') as archive:
+        archive.printdir()

--- a/src/processing/common/export.py
+++ b/src/processing/common/export.py
@@ -1,12 +1,8 @@
 import logging
-import sys
 import zipfile
 
-from bs4 import BeautifulSoup
 from csv import DictWriter
 from pathlib import Path
-
-from django.core.management import BaseCommand
 
 from processing.models import Batch, File, Item
 
@@ -38,7 +34,7 @@ def export(batch_selected, export_path):
         yield f'Number of items in progress: {items_in_progress.count()}<br>'
         yield f'Number of items not started: {items_not_started.count()}</div>'
 
-        # Disabled user input to proceed
+        # Disabled command line input to proceed
         # result = input('Continue export? Please answer yes or no: ')
         # if result == 'yes':
         # pass
@@ -127,7 +123,3 @@ def export(batch_selected, export_path):
     with zipfile.ZipFile(zip_file, mode='w') as archive:
         for file_path in directory.rglob('*'):
             archive.write(file_path, arcname=file_path.relative_to(directory))
-
-    # Disabled info about created zip file
-    # with zipfile.ZipFile(zip_file, mode='r') as archive:
-    # archive.printdir()

--- a/src/processing/common/finalize_redactions.py
+++ b/src/processing/common/finalize_redactions.py
@@ -1,0 +1,29 @@
+import logging
+
+from bs4 import BeautifulSoup
+
+from processing.models import Item
+
+logger = logging.getLogger(__name__)
+
+
+def redact_final(html):
+    soup = BeautifulSoup(html, 'lxml')
+    tags = soup.find_all('del', {'class': 'redacted'})
+
+    for tag in tags:
+        new_string = '▊▊▊▊▊▊▊▊▊▊'
+        tag = tag.replace_with(new_string)
+
+    html = str(soup)
+    return html
+
+def convert_redaction(batch_selected):
+    items = Item.objects.filter(batch=batch_selected)
+    item = Item.objects.all()
+    for item in items:
+        logger.info(f'Marking: {item.id}, {item.title}')
+        html = item.body_redact
+        html = redact_final(html)
+        item.body_final = html
+        item.save(update_fields=['body_final'])

--- a/src/processing/common/finalize_redactions.py
+++ b/src/processing/common/finalize_redactions.py
@@ -18,12 +18,16 @@ def redact_final(html):
     html = str(soup)
     return html
 
+
 def convert_redaction(batch_selected):
     items = Item.objects.filter(batch=batch_selected)
     item = Item.objects.all()
+    logger.info(f'Converting Batch {batch_selected}')
     for item in items:
         logger.info(f'Marking: {item.id}, {item.title}')
+        yield f'Converting: {item.id}, {item.title}<br>'
         html = item.body_redact
         html = redact_final(html)
         item.body_final = html
         item.save(update_fields=['body_final'])
+    yield f'Completed Converting Batch {batch_selected}'

--- a/src/processing/management/commands/export.py
+++ b/src/processing/management/commands/export.py
@@ -1,20 +1,13 @@
 import logging
-import sys
-import zipfile
 
-from bs4 import BeautifulSoup
-from csv import DictWriter
 from pathlib import Path
 
 from django.core.management import BaseCommand
 
-from processing.models import Batch, File, Item
 from processing.common.export import export
 
 
 logger = logging.getLogger(__name__)
-
-HEADER = ['Identifier', 'Title', 'Date', 'Creator', 'Format', 'Rights Statement', 'FILES', 'Object Type']
 
 
 class Command(BaseCommand):

--- a/src/processing/management/commands/finalize_redactions.py
+++ b/src/processing/management/commands/finalize_redactions.py
@@ -1,25 +1,11 @@
 import logging
 
-from bs4 import BeautifulSoup
-
 from django.core.management import BaseCommand
 
-from processing.models import Item
+from processing.common.finalize_redactions import convert_redaction
 
 
 logger = logging.getLogger(__name__)
-
-
-def redact_final(html):
-    soup = BeautifulSoup(html, 'lxml')
-    tags = soup.find_all('del', {'class': 'redacted'})
-
-    for tag in tags:
-        new_string = '▊▊▊▊▊▊▊▊▊▊'
-        tag = tag.replace_with(new_string)
-
-    html = str(soup)
-    return html
 
 
 class Command(BaseCommand):
@@ -29,14 +15,5 @@ class Command(BaseCommand):
         parser.add_argument('batch_selected', type=int, help='Batch to have redactions finalized.')
 
     def handle(self, *args, **options):
-        items = Item.objects.filter(batch=options['batch_selected'])
-        item = Item.objects.all()
-        for item in items:
-            logger.info(f'Marking: {item.id}, {item.title}')
-
-            html = item.body_redact
-
-            html = redact_final(html)
-
-            item.body_final = html
-            item.save(update_fields=['body_final'])
+        batch_selected = batch=options['batch_selected']
+        convert_redaction(batch_selected)

--- a/src/processing/tables.py
+++ b/src/processing/tables.py
@@ -13,6 +13,7 @@ class BatchList(tables.Table):
     assigned_to = Column(attrs={'th': {'class': 'text-decoration-line-through text-muted'}}, orderable=False)
     id = Column(verbose_name='ID')
     name = Column(verbose_name='Batch Name')
+    finalize = TemplateColumn(template_name='tables/finalize.html', orderable=False)
 
 
 class ItemList(tables.Table):

--- a/src/processing/templates/base.html
+++ b/src/processing/templates/base.html
@@ -4,6 +4,11 @@
 <head>
     <meta charset="UTF-8">
     <title>Scutes</title>
+    <!-- HTMX -->
+    <script src="https://unpkg.com/htmx.org@1.9.9"
+        integrity="sha384-QFjmbokDn2DjBjq+fM+8LUIVrAgqcNW2s0PjAxHETgRn9l4fvX31ZxDxvwQnyMOX"
+        crossorigin="anonymous"></script>
+
     <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">

--- a/src/processing/templates/finalize_batch.html
+++ b/src/processing/templates/finalize_batch.html
@@ -1,5 +1,4 @@
 {% extends "base.html" %}
-
 {% load static %}
 
 {% block content %}
@@ -9,7 +8,6 @@
         <h3>Batch ID: {{ object.pk }}</h3>
     </div>
     <div class="row p-1">
-
         <div class="col">
             <div class="card p-3 mt-1" style="height:700px;">
                 <button class="btn btn-primary" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
@@ -17,7 +15,6 @@
                     hx-swap="innerHTML" value="{{ object.pk }}" name="id">
                     Convert Redactions
                 </button>
-
                 <p class="card-text">
                 <div class="overflow-auto">
                     <div id="redactDataLocation"></div>
@@ -25,7 +22,6 @@
                 </p>
             </div>
         </div>
-
         <div class="col">
             <div class="card p-3 mt-1" style="height:700px;">
                 <button class="btn btn-primary" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
@@ -33,7 +29,6 @@
                     hx-swap="innerHTML" value="{{ object.pk }}" name="id">
                     Export
                 </button>
-
                 <p class="card-text">
                 <div class="overflow-auto">
                     <div id="exportDataLocation"></div>
@@ -41,7 +36,6 @@
                 </p>
             </div>
         </div>
-
     </div>
 </div>
 {% endblock %}

--- a/src/processing/templates/finalize_batch.html
+++ b/src/processing/templates/finalize_batch.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+
+{% load static %}
+
+{% block content %}
+<div class="container-fluid">
+    <div class="row p-1">
+        <h1>Finalize Batch</h1>
+        <h3>Batch ID: {{ object.pk }}</h3>
+    </div>
+    <div class="row p-1">
+
+        <div class="col">
+            <div class="card p-3 mt-1" style="height:700px;">
+                <button class="btn btn-primary" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                    hx-post="/batch_redaction/" hx-target="#redactDataLocation" hx-include="[name='id']"
+                    hx-swap="innerHTML" value="{{ object.pk }}" name="id">
+                    Convert Redactions
+                </button>
+
+                <p class="card-text">
+                <div class="overflow-auto">
+                    <div id="redactDataLocation"></div>
+                </div>
+                </p>
+            </div>
+        </div>
+
+        <div class="col">
+            <div class="card p-3 mt-1" style="height:700px;">
+                <button class="btn btn-primary" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                    hx-post="/batch_export/" hx-target="#exportDataLocation" hx-include="[name='id']"
+                    hx-swap="innerHTML" value="{{ object.pk }}" name="id">
+                    Export
+                </button>
+
+                <p class="card-text">
+                <div class="overflow-auto">
+                    <div id="exportDataLocation"></div>
+                </div>
+                </p>
+            </div>
+        </div>
+
+    </div>
+</div>
+{% endblock %}

--- a/src/processing/templates/item_view.html
+++ b/src/processing/templates/item_view.html
@@ -3,7 +3,6 @@
 
 {% block content %}
 <div class="container-fluid p-2">
-
     <div class="row">
         <div class="col-md-8 mb-0">
             <h1>Item View</h1>
@@ -11,7 +10,6 @@
         <!-- item nav -->
         <div class="col-md-4">
             <div class="d-grid gap-2 d-md-flex justify-content-md-end">
-
                 {% if previous_object_id %}
                 <button type="button" class="btn btn-info btn-sm">
                     <a class="nav-link" href="{% url 'itemupdateview' previous_object_id %}">
@@ -32,7 +30,6 @@
                     </svg>
                     Prev Item</button>
                 {% endif %}
-
                 {% if next_object_id %}
                 <button type="button" class="btn btn-info btn-sm">
                     <a class="nav-link" href="{% url 'itemupdateview' next_object_id %}">
@@ -54,7 +51,6 @@
                     </svg>
                 </button>
                 {% endif %}
-
                 <button type="button" class="btn btn-warning btn-sm">
                     <a class="nav-link" href="{% url 'itemlistview' item.batch.id %}">List View with Fresh Start</a>
                 </button>
@@ -63,8 +59,6 @@
                         List View with Current Filters
                     </a>
                 </button>
-
-
             </div>
         </div>
     </div>
@@ -72,7 +66,6 @@
     <form method="post" enctype="multipart/form-data" class="card p-3 mt-3">
         {% csrf_token %}
         {{ form.media}}
-
         <div class="row">
             <div class="col-md-10 mb-0">
                 <h3>ID: {{ object.pk }}</h3>
@@ -83,7 +76,6 @@
             <div class="col-md-2">
             </div>
         </div>
-
         <div class="row">
             <div class="col-md-5 mb-0 bg-light">
                 {{ form.body_original|as_crispy_field }}

--- a/src/processing/templates/tables/finalize.html
+++ b/src/processing/templates/tables/finalize.html
@@ -1,0 +1,1 @@
+<a class="btn btn-outline-primary btn-sm" href="{% url 'finalizebatchview' record.id %}">Finalize</a>

--- a/src/processing/views.py
+++ b/src/processing/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
 from django.http.response import StreamingHttpResponse
@@ -10,6 +11,7 @@ from django.views.generic.base import TemplateView
 from django_tables2 import SingleTableMixin, SingleTableView
 
 import logging
+import os
 import pickle
 import time
 import sys
@@ -212,7 +214,7 @@ def batch_redaction(request):
 
 def batch_export(request):
     batch_selected = request.POST['id']
-    export_path = '/Users/tkanke/Downloads/scutes'  # TODO YAY! Hardcoded Value
+    export_path = os.path.join(settings.MEDIA_ROOT, 'export')
     stream = export(batch_selected, export_path)
     response = StreamingHttpResponse(stream, status=200, content_type='text/event-stream')
     response['Cache-Control'] = 'no-cache'

--- a/src/processing/views.py
+++ b/src/processing/views.py
@@ -1,4 +1,5 @@
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.core import management
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls import reverse
@@ -30,6 +31,16 @@ class BatchList(LoginRequiredMixin, SingleTableView):
     template_name = 'batch_list.html'
     paginate_by = 10
     context_object_name = 'batch'
+
+    def run_management_command(self, object_id):
+        batch_number = 1
+        run_mark_redaction = management.call_command('mark_redaction', batch_number)
+        return run_mark_redaction
+
+    def get_context_data(self, **kwargs):
+        context = super(BatchList, self).get_context_data(**kwargs)
+        context['run_management_command'] = self.run_management_command(self.object.id)
+        return context
 
 
 class ItemListView(LoginRequiredMixin, SingleTableMixin, ListView):

--- a/src/processing/views.py
+++ b/src/processing/views.py
@@ -32,16 +32,6 @@ class BatchList(LoginRequiredMixin, SingleTableView):
     paginate_by = 10
     context_object_name = 'batch'
 
-    def run_management_command(self, object_id):
-        batch_number = 1
-        run_mark_redaction = management.call_command('mark_redaction', batch_number)
-        return run_mark_redaction
-
-    def get_context_data(self, **kwargs):
-        context = super(BatchList, self).get_context_data(**kwargs)
-        context['run_management_command'] = self.run_management_command(self.object.id)
-        return context
-
 
 class ItemListView(LoginRequiredMixin, SingleTableMixin, ListView):
     model = Item

--- a/src/processing/views.py
+++ b/src/processing/views.py
@@ -1,9 +1,8 @@
 from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
-from django.http import HttpResponse, HttpResponseForbidden, HttpResponseRedirect
+from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.http.response import StreamingHttpResponse
-from django.shortcuts import redirect, render
-from django.template.response import TemplateResponse
+from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.http import urlencode
 from django.views.generic import ListView, DetailView, UpdateView
@@ -13,23 +12,16 @@ from django_tables2 import SingleTableMixin, SingleTableView
 import logging
 import os
 import pickle
-import time
-import sys
 
-from bs4 import BeautifulSoup
 from base64 import b64encode, b64decode
-from queue import Queue, Empty
-from threading import Thread, current_thread
 
 from .filters import ItemFilter
 from .forms import ItemUpdateForm
 from .models import Batch, Item
 from .tables import BatchList, ItemList
-
-from processing.common.finalize_redactions import convert_redaction
 from processing.common.export import export
+from processing.common.finalize_redactions import convert_redaction
 
-import subprocess as sp
 
 logger = logging.getLogger(__name__)
 

--- a/src/scutes/urls.py
+++ b/src/scutes/urls.py
@@ -20,7 +20,16 @@ from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 
-from processing.views import BatchList, Dashboard, Index, ItemListView, ItemUpdateView
+from processing.views import (
+    BatchList,
+    batch_export,
+    batch_redaction,
+    Dashboard,
+    FinalizeBatchView,
+    Index,
+    ItemListView,
+    ItemUpdateView,
+)
 
 urlpatterns = [
     path('__debug__/', include('debug_toolbar.urls')),
@@ -30,6 +39,9 @@ urlpatterns = [
     path('dashboard/', Dashboard.as_view(), name='dashboard'),
     path('', Index.as_view(), name='index'),
     path('itemlist/<int:batch>/', ItemListView.as_view(), name='itemlistview'),
+    path('finalizebatch/<int:pk>/', FinalizeBatchView.as_view(), name='finalizebatchview'),
+    path('batch_redaction/', batch_redaction, name='batch_redaction'),
+    path('batch_export/', batch_export, name='batch_export'),
     path('itemview/<int:pk>/', ItemUpdateView.as_view(), name='itemupdateview'),
     path('ckeditor5/', include('django_ckeditor_5.urls')),
     path('accounts/', include('django.contrib.auth.urls')),


### PR DESCRIPTION
Add ability to run finalize_redactions.py and export.py scripts in Scutes user view by:

- Refactor common logic into a separate function, then call it in the management command and view
- Add mechanism to run finalize and export scripts by batch
- Add check that all items in batch have been reviewed (have this for export, should this be present for finalize_redactions?)
- Add notify user if script completes/fails

https://umd-dit.atlassian.net/browse/LIBWHCA-140